### PR TITLE
Refatora exportação DXF para chamada direta em C#

### DIFF
--- a/TNKDxf/ExportadoraDxf.cs
+++ b/TNKDxf/ExportadoraDxf.cs
@@ -26,6 +26,8 @@ namespace TNKDxf
 
             string dwgxportParams = "export outputDirectory=\""  + DWGFolder + "\"";
 
+            //string configName = "TNK_DXF";
+            //string dwgxportParams = "export outputDirectory=\"" + DWGFolder + "\" selectionConfig=\"" + configName + "\"";
 
             Process NewProcess = new Process();
 

--- a/TNKDxf/Handles/ExtratorDXFs.cs
+++ b/TNKDxf/Handles/ExtratorDXFs.cs
@@ -171,9 +171,10 @@ namespace TNKDxf.Handles
 
                 TotalEsperado = _desenhos.Count;
 
+
                 if (versao == "2024.0")
                 {
-                    Operation.RunMacro(@"C:\ProgramData\Trimble\Tekla Structures\2024.0\Environments\common\macros\modeling\ExportaDxf.cs");
+                    ExportadoraDxf.Run(PastaSaida);
                     _foramExtraidos = true;
                 }
 


### PR DESCRIPTION
Remove execução de macro externa para exportação DXF na versão 2024.0, utilizando agora chamada direta ao método ExportadoraDxf.Run. Também simplifica os parâmetros de exportação DWG, removendo a configuração de seleção específica.